### PR TITLE
Feat/options only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,35 @@
   "requires": true,
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@apidevtools/openapi-schemas": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
-      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
     },
     "@apidevtools/swagger-methods": {
       "version": "3.0.2",
@@ -25,16 +41,16 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "@apidevtools/openapi-schemas": "^2.0.4",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
+        "z-schema": "^5.0.1"
       }
     },
     "@babel/cli": {
@@ -3587,23 +3603,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
-      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -3713,7 +3721,8 @@
     "@types/node": {
       "version": "14.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3735,9 +3744,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -3874,42 +3883,85 @@
       }
     },
     "@whook/http-router": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@whook/http-router/-/http-router-5.1.6.tgz",
-      "integrity": "sha512-fdTlONQM6zYCeY72tlotLPFiAZ1O6FBW2BlP1VfSXS7FLfQU0xSG9w6MtlDR2xPm0FvsUOmmmUNI8A6WZgi2/w==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@whook/http-router/-/http-router-8.5.0.tgz",
+      "integrity": "sha512-Hu0STCHBNngkcGNdBg/5RU40rCoPhOLiuCBnkWvWdm5YIq5FRkmlnbz8kdmXRpro0SE/BvwWuD2ktgFX+D+3PA==",
       "requires": {
         "@apidevtools/swagger-parser": "^10.0.2",
-        "@types/qs": "^6.9.5",
-        "@whook/http-transaction": "^5.1.4",
-        "ajv": "^6.12.6",
+        "@types/qs": "^6.9.6",
+        "@whook/http-transaction": "^8.5.0",
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.0",
         "bytes": "^3.1.0",
-        "camelcase": "^6.1.0",
+        "camelcase": "^6.2.0",
         "content-type": "^1.0.4",
         "first-chunk-stream": "^4.0.0",
-        "knifecycle": "^10.0.3",
+        "knifecycle": "^11.1.1",
         "miniquery": "^1.1.2",
-        "ms": "^2.1.2",
+        "ms": "^2.1.3",
         "negotiator": "^0.6.2",
-        "openapi-types": "^7.0.1",
-        "qs": "^6.9.4",
-        "siso": "^4.0.3",
-        "strict-qs": "^6.1.3",
-        "yerror": "^5.0.0",
-        "yhttperror": "^5.0.0"
+        "openapi-types": "^9.3.0",
+        "qs": "^6.10.1",
+        "siso": "^4.0.4",
+        "strict-qs": "^6.1.4",
+        "type-fest": "^2.3.3",
+        "yerror": "^6.0.1",
+        "yhttperror": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "type-fest": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.1.tgz",
+          "integrity": "sha512-JDcsxbLR6Z6OcL7TnGAAAGQrY4g7Q4EEALMT4Kp6FQuIc0JLQvOF3l7ejFvx8o5GmLlfMseTWUL++sYFP+o8kw=="
+        }
       }
     },
     "@whook/http-transaction": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@whook/http-transaction/-/http-transaction-5.1.4.tgz",
-      "integrity": "sha512-AaNs0YoPX3CLEAfdvBEiggVTSaFhJf0tm1zx+enjtOImjpZIkPS9VjoB61swBiymi47jAeLpa/Sg/Eo5yYI4QQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@whook/http-transaction/-/http-transaction-8.5.0.tgz",
+      "integrity": "sha512-mE9+XP9h6IS3q0y5KrzLX69zvRMl5XRiv5KCiX07q2ZhSBVuXtdHU2ezEpS4XgQIBeW+YmaQNja3uvr3W9555A==",
       "requires": {
-        "common-services": "^8.0.2",
-        "knifecycle": "^10.0.3",
-        "ms": "^2.1.2",
-        "openapi-types": "^7.0.1",
-        "statuses": "^2.0.0",
-        "yerror": "^5.0.0",
-        "yhttperror": "^5.0.0"
+        "common-services": "^9.0.1",
+        "knifecycle": "^11.1.1",
+        "ms": "^2.1.3",
+        "openapi-types": "^9.3.0",
+        "statuses": "^2.0.1",
+        "type-fest": "^2.3.3",
+        "yerror": "^6.0.1",
+        "yhttperror": "^6.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "type-fest": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.1.tgz",
+          "integrity": "sha512-JDcsxbLR6Z6OcL7TnGAAAGQrY4g7Q4EEALMT4Kp6FQuIc0JLQvOF3l7ejFvx8o5GmLlfMseTWUL++sYFP+o8kw=="
+        }
       }
     },
     "JSONStream": {
@@ -3966,11 +4018,38 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "ansi-colors": {
@@ -4042,6 +4121,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -4548,7 +4628,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -5065,14 +5144,21 @@
       "dev": true
     },
     "common-services": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/common-services/-/common-services-8.0.2.tgz",
-      "integrity": "sha512-ZvDqoyN+anDLZv68VGsaWX2UpkkfWbfFxJph2sRgSpD9LYHYVsh8nqGh+AGBYsXjDfqEHqxMWsoZC5zutKAunQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/common-services/-/common-services-9.0.1.tgz",
+      "integrity": "sha512-jF0Gdg5ycK2BU2NZLRxdFvw7ZyYV29UdTtTMlwN5jKit+ASjb7FiEjlZUB+U2WF+KDlvqlJRQNQWBHKyvHT2Mw==",
       "requires": {
-        "@types/node": "^14.11.10",
-        "knifecycle": "^10.0.3",
-        "sinon": "^9.2.0",
-        "yerror": "^5.0.0"
+        "@types/node": "^14.14.37",
+        "knifecycle": "11.1.1",
+        "sinon": "^10.0.1",
+        "yerror": "^6.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+          "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw=="
+        }
       }
     },
     "commondir": {
@@ -6098,7 +6184,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -6499,7 +6586,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6742,8 +6830,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6767,7 +6854,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -7315,7 +7401,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7328,8 +7413,7 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -9245,6 +9329,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -9535,7 +9620,8 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9586,9 +9672,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -9612,12 +9698,20 @@
       "dev": true
     },
     "knifecycle": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/knifecycle/-/knifecycle-10.0.3.tgz",
-      "integrity": "sha512-+O0vl3B8W4z1QGvPxm7IB+9bS7U5C0YETLmB/qZw5lHjcyDFr+04yufXUfKmBth0nGfVQDAqw1ca4YW0xofwoQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/knifecycle/-/knifecycle-11.1.1.tgz",
+      "integrity": "sha512-Q/giTQms4wYS4lBwKjrfZSe5MPQ65gqvvOLnATSLyHMpPQxUO4FT7BGZYr5xpDIteXVrqH+JR8JWmEhbmk20qw==",
       "requires": {
-        "debug": "^4.2.0",
-        "yerror": "^5.0.0"
+        "debug": "^4.3.1",
+        "type-fest": "^1.0.1",
+        "yerror": "^6.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
       }
     },
     "lcov-parse": {
@@ -10394,15 +10488,25 @@
       "dev": true
     },
     "nise": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
-      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/fake-timers": "^7.0.4",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "node-int64": {
@@ -10568,6 +10672,11 @@
       "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -10629,9 +10738,9 @@
       }
     },
     "openapi-types": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-7.0.1.tgz",
-      "integrity": "sha512-6pi4/Fw+JIW1HHda2Ij7LRJ5QJ8f6YzaXnsRA6m44BJz8nLq/j5gVFzPBKJo+uOFhAeHqZC/3uzhTpYPga3Q/A=="
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
+      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -10979,9 +11088,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -11461,8 +11573,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -11639,9 +11750,9 @@
       }
     },
     "schema2dts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/schema2dts/-/schema2dts-3.0.0.tgz",
-      "integrity": "sha512-BorsRrWZ/6cfg7ZPqqFd3hpJSR8A+WYF13vYXm03d+qhaueUsb1x9ifeyoKQhheBWaYfFJ1v6AJgmqsPUiEwXA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/schema2dts/-/schema2dts-3.0.1.tgz",
+      "integrity": "sha512-Ba2W8li4Md0jG2ilmP47vWAhrlqFvWehq1OclNJ7jhw8xTPb3yFIUfFScf7BxJf3KnOYj7dA/rY55bmErot74Q==",
       "requires": {
         "@types/json-schema": "^7.0.7",
         "camelcase": "^6.2.0",
@@ -11654,11 +11765,6 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-8.0.0.tgz",
           "integrity": "sha512-dcHYyCDOAy4QQTrur5Sn1L3lPVspB7rd04Rw/Q7AsMvfV797IiWgmKziFCbq8VhnBoREU/SPPSBDxtK9Biwa1g=="
-        },
-        "yerror": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/yerror/-/yerror-6.0.1.tgz",
-          "integrity": "sha512-0Bxo+NyeucjxhmPB5z3lmI/N/cOu8L1Q8JVta6/I5G6J/JhCSSPwk8qt9N4yOFSjwkvhDwzUSQglfBIAllvi1Q=="
         }
       }
     },
@@ -11730,6 +11836,16 @@
       "dev": true,
       "optional": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -11737,27 +11853,36 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
-      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.1.tgz",
+      "integrity": "sha512-1rf86mvW4Mt7JitEIgmNaLXaWnrWd/UrVKZZlL+kbeOujXVf9fmC4kQEQ/YeHoiIA23PLNngYWK+dngIx/AumA==",
       "requires": {
         "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.2.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/samsam": "^6.0.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^5.0.1",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "siso": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/siso/-/siso-4.0.3.tgz",
-      "integrity": "sha512-6zUwOSADojXqYlSEpvZVUb//lPVzIe3k3N0REdo2IrHt4S9hyBPvuuGHL1t4611dULBdzoeZWur88B3oRZVd0g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/siso/-/siso-4.0.4.tgz",
+      "integrity": "sha512-gusRdHBg3bhpgSO+knFNzhtwYAKrk3c+a9hDA7jE5SwG9ljV4o9d2nIopCYKIEJ013mJqw4jDNwpBFxnj1CDzQ==",
       "requires": {
-        "debug": "^4.1.1",
+        "debug": "^4.3.1",
         "regexp-tpl": "^2.0.1",
-        "yerror": "^5.0.0"
+        "yerror": "^6.0.0"
       }
     },
     "sisteransi": {
@@ -12089,7 +12214,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -12147,9 +12273,9 @@
       }
     },
     "statuses": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.0.tgz",
-      "integrity": "sha512-w9jNUUQdpuVoYqXxnyOakhckBbOxRaoYqJscyIBYCS5ixyCnO7nQn7zBZvP9zf5QOPZcz2DLUpE3KsNPbJBOFA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -12184,12 +12310,12 @@
       "dev": true
     },
     "strict-qs": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/strict-qs/-/strict-qs-6.1.3.tgz",
-      "integrity": "sha512-MloP1lFo9fGGUy7Hxc+w6i95GHfaBqCDiWOBcH9OaWAtC/1bYWzueCfTnlrrPrKWTMMRNsPPyxW1odVGGErnzQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/strict-qs/-/strict-qs-6.1.4.tgz",
+      "integrity": "sha512-rJ1hf3uCokrkaA1yynoMdoUhISx3XRMl4bmzW5QNqwpkFKOcs8hsohUst2i+Cdmb6WTeEyKbvCu1Uo2sRxzOhg==",
       "requires": {
-        "debug": "^4.1.1",
-        "yerror": "^5.0.0"
+        "debug": "^4.3.1",
+        "yerror": "^6.0.0"
       }
     },
     "string-length": {
@@ -12893,9 +13019,9 @@
       }
     },
     "validator": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -13256,16 +13382,16 @@
       "dev": true
     },
     "yerror": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yerror/-/yerror-5.0.0.tgz",
-      "integrity": "sha512-b4I0lhWrHDcFGVSP5SkSqGL8P+cuIvmoGvWfnm7YLMWMvUwngCZy9qNLjRbnABh02K/q/yFzBBz8dQuUVEoMAw=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/yerror/-/yerror-6.0.1.tgz",
+      "integrity": "sha512-0Bxo+NyeucjxhmPB5z3lmI/N/cOu8L1Q8JVta6/I5G6J/JhCSSPwk8qt9N4yOFSjwkvhDwzUSQglfBIAllvi1Q=="
     },
     "yhttperror": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yhttperror/-/yhttperror-5.0.0.tgz",
-      "integrity": "sha512-n7psz2rh/SX3k34qkBMXMQm5304p4shx/KrfdH3x04RTU2ep9qnL7QWx/crsM7FXjmLJkzeoKHMY44ZQjdjFTg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/yhttperror/-/yhttperror-6.0.1.tgz",
+      "integrity": "sha512-gfMNgU+n3pv1oYSnT62smiLVepdPnYyimb6+oLbmt4Nhx1ws/h8wh1bExXRu+7sC0AuGmfbBNzMDngNfZJyZmg==",
       "requires": {
-        "yerror": "^5.0.0"
+        "yerror": "^6.0.1"
       }
     },
     "yocto-queue": {
@@ -13275,14 +13401,14 @@
       "dev": true
     },
     "z-schema": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.1.tgz",
+      "integrity": "sha512-Gp8xU2lULhREqTWj9t4BEAeA7M835n4fWJ9KjGWksV3wmLUdOJo2hAr+QYvkVZIGOOTyeN274g1f95dKRsgYgQ==",
       "requires": {
         "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^12.0.0"
+        "validator": "^13.6.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@whook/http-router": "^5.1.6",
+    "@whook/http-router": "^8.5.0",
     "camelcase": "^6.2.0",
-    "schema2dts": "^3.0.0"
+    "schema2dts": "^3.0.1"
   },
   "peerDependencies": {
     "axios": "^0.21.1"

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -7,14 +7,34 @@ exports[`generateSDKFromOpenAPI should work 1`] = `
 // do not change it in place it would be overridden
 // by the next build
 
+import querystring from 'querystring';
+import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+
 type Writeable<T extends { [x: string]: unknown }> = {
   [P in keyof T]: T[P];
 };
-type QueryParams = {
+export type Method = 'options' | 'get' | 'head' |'post' | 'put' | 'patch' | 'delete';
+export type QueryParams = {
   [name: string]: string | number | string[] | number[] | boolean | undefined;
 };
-type Headers = Record<string, string>;
-
+export type Headers = Record<string, string>;
+export type URIBuilderOptions = {
+  baseURL?: string;
+};
+export type InputBuilderOptions = URIBuilderOptions & {
+    headers?: Headers;
+};
+export type URIData = {
+  baseURL: string;
+  path: string;
+  params: QueryParams;
+};
+export type HTTPRequest<T> = URIData & {
+  method: Method;
+  headers: Headers;
+  body: T;
+};
 export type { APITypes, Components };
 
 declare namespace APITypes {
@@ -148,9 +168,14 @@ declare namespace Components {
     }
 }
 
-import type { AxiosRequestConfig } from 'axios';
-import querystring from 'querystring';
-import axios from 'axios';
+const DEFAULT_BASE_URL = 'http://192.168.10.149:8000/v3';
+const URI_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+};
+const INPUT_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+  headers: {},
+};
 
 /**
  * A basic Whook server
@@ -166,11 +191,109 @@ const API = {
   putEcho,
 };
 
+export const APIURIBuilders = {
+  getOpenAPI: buildGetOpenAPIURI,
+  getPing: buildGetPingURI,
+  getDelay: buildGetDelayURI,
+  getDiagnostic: buildGetDiagnosticURI,
+  getTime: buildGetTimeURI,
+  putEcho: buildPutEchoURI,
+};
+
+export const APIMethods = {
+  getOpenAPI: 'get',
+  getPing: 'get',
+  getDelay: 'get',
+  getDiagnostic: 'get',
+  getTime: 'get',
+  putEcho: 'put',
+} as const;
+
+export const APIInputBuilders = {
+  getOpenAPI: buildGetOpenAPIInput,
+  getPing: buildGetPingInput,
+  getDelay: buildGetDelayInput,
+  getDiagnostic: buildGetDiagnosticInput,
+  getTime: buildGetTimeInput,
+  putEcho: buildPutEchoInput,
+};
+
+
+/**
+ * Build the \\"getOpenAPI\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetOpenAPIURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'openAPI',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getOpenAPI\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetOpenAPIInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getOpenAPI;
+  const __uriData = buildGetOpenAPIURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
 
 /**
  * Get API documentation.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -178,32 +301,23 @@ const API = {
  */
 async function getOpenAPI(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetOpenAPI.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'openAPI',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetOpenAPIInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -213,10 +327,82 @@ async function getOpenAPI(
   } as APITypes.GetOpenAPI.Output;
 }
 
+
+/**
+ * Build the \\"getPing\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetPingURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'ping',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getPing\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetPingInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getPing;
+  const __uriData = buildGetPingURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Checks API's availability.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -224,32 +410,23 @@ async function getOpenAPI(
  */
 async function getPing(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetPing.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'ping',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetPingInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -259,11 +436,100 @@ async function getPing(
   } as APITypes.GetPing.Output;
 }
 
+
+/**
+ * Build the \\"getDelay\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {number} parameters.duration
+ * Duration in milliseconds
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetDelayURI(
+  {
+    duration,
+  } : Pick<APITypes.GetDelay.Input,
+    'duration'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(duration == null) {
+    throw new Error('Missing required parameter : duration. Value : ' +  duration);
+  }
+
+  const __pathParts = [
+    'delay',
+  ];
+  const __qs = cleanQuery({
+    duration: duration,
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getDelay\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {number} parameters.duration
+ * Duration in milliseconds
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetDelayInput(
+  {
+    duration,
+    xApplicationVersion,
+  } : APITypes.GetDelay.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getDelay;
+  const __uriData = buildGetDelayURI({
+    duration,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+      'X-Application-Version': xApplicationVersion,
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Answer after a given delay.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {number} parameters.duration
+ * The parameters provided to build them (destructured)
+* @param {number} parameters.duration
  * Duration in milliseconds
  * @param {Object} options
  * Options to override Axios request configuration
@@ -272,41 +538,28 @@ async function getPing(
  */
 async function getDelay(
   {
-  duration,
-  xApplicationVersion,
+    duration,
+    xApplicationVersion,
   } : APITypes.GetDelay.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetDelay.Output>> {
-
-
-  if( duration == null) {
-    throw new Error('Missing required parameter : duration. Value : ' +  duration);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'delay',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-    'X-Application-Version': xApplicationVersion,
-  });
-  const qs = cleanQuery({
-    duration: duration,
-  });
-  const data = undefined;
+  const httpRequest = buildGetDelayInput({
+    duration,
+    xApplicationVersion,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -316,10 +569,82 @@ async function getDelay(
   } as APITypes.GetDelay.Output;
 }
 
+
+/**
+ * Build the \\"getDiagnostic\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetDiagnosticURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'diag',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getDiagnostic\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetDiagnosticInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getDiagnostic;
+  const __uriData = buildGetDiagnosticURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Returns current API's transactions.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -327,32 +652,23 @@ async function getDelay(
  */
 async function getDiagnostic(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetDiagnostic.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'diag',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetDiagnosticInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -362,10 +678,82 @@ async function getDiagnostic(
   } as APITypes.GetDiagnostic.Output;
 }
 
+
+/**
+ * Build the \\"getTime\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetTimeURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'time',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getTime\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetTimeInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getTime;
+  const __uriData = buildGetTimeURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Get API internal clock date.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -373,32 +761,23 @@ async function getDiagnostic(
  */
 async function getTime(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetTime.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'time',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetTimeInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -408,12 +787,88 @@ async function getTime(
   } as APITypes.GetTime.Output;
 }
 
+
+/**
+ * Build the \\"putEcho\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildPutEchoURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'echo',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"putEcho\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildPutEchoInput(
+  {
+    body,
+  } : APITypes.PutEcho.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.PutEcho.Input['body']> {
+
+
+
+  const __method = APIMethods.putEcho;
+  const __uriData = buildPutEchoURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Echoes what it takes.
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -423,32 +878,24 @@ async function putEcho(
   {
     body,
   } : APITypes.PutEcho.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.PutEcho.Output>> {
-
-
-
-  const method = 'put';
-  const urlParts = [
-    'echo',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildPutEchoInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -492,14 +939,34 @@ exports[`generateSDKFromOpenAPI should work with Pet Store 1`] = `
 // do not change it in place it would be overridden
 // by the next build
 
+import querystring from 'querystring';
+import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+
 type Writeable<T extends { [x: string]: unknown }> = {
   [P in keyof T]: T[P];
 };
-type QueryParams = {
+export type Method = 'options' | 'get' | 'head' |'post' | 'put' | 'patch' | 'delete';
+export type QueryParams = {
   [name: string]: string | number | string[] | number[] | boolean | undefined;
 };
-type Headers = Record<string, string>;
-
+export type Headers = Record<string, string>;
+export type URIBuilderOptions = {
+  baseURL?: string;
+};
+export type InputBuilderOptions = URIBuilderOptions & {
+    headers?: Headers;
+};
+export type URIData = {
+  baseURL: string;
+  path: string;
+  params: QueryParams;
+};
+export type HTTPRequest<T> = URIData & {
+  method: Method;
+  headers: Headers;
+  body: T;
+};
 export type { APITypes, Components };
 
 declare namespace APITypes {
@@ -654,32 +1121,32 @@ declare namespace APITypes {
     }
     export namespace CreateUser {
         export type Body = Components.RequestBodies.CreateUserRequestBody;
-        export type Output = Responses.Default;
+        export type Output = Responses.$default;
         export type Input = {
             readonly body: Body;
         };
         export namespace Responses {
-            export type $default = Components.Responses.createUserResponsedefault<default>;
+            export type $default = Components.Responses.createUserResponsedefault<number>;
         }
     }
     export namespace CreateUsersWithArrayInput {
         export type Body = Components.RequestBodies.UserArray;
-        export type Output = Responses.Default;
+        export type Output = Responses.$default;
         export type Input = {
             readonly body: Body;
         };
         export namespace Responses {
-            export type $default = Components.Responses.createUsersWithArrayInputResponsedefault<default>;
+            export type $default = Components.Responses.createUsersWithArrayInputResponsedefault<number>;
         }
     }
     export namespace CreateUsersWithListInput {
         export type Body = Components.RequestBodies.UserArray;
-        export type Output = Responses.Default;
+        export type Output = Responses.$default;
         export type Input = {
             readonly body: Body;
         };
         export namespace Responses {
-            export type $default = Components.Responses.createUsersWithListInputResponsedefault<default>;
+            export type $default = Components.Responses.createUsersWithListInputResponsedefault<number>;
         }
     }
     export namespace LoginUser {
@@ -698,10 +1165,10 @@ declare namespace APITypes {
         }
     }
     export namespace LogoutUser {
-        export type Output = Responses.Default;
+        export type Output = Responses.$default;
         export type Input = {};
         export namespace Responses {
-            export type $default = Components.Responses.logoutUserResponsedefault<default>;
+            export type $default = Components.Responses.logoutUserResponsedefault<number>;
         }
     }
     export namespace GetUserByName {
@@ -1089,9 +1556,14 @@ declare namespace Components {
     }
 }
 
-import type { AxiosRequestConfig } from 'axios';
-import querystring from 'querystring';
-import axios from 'axios';
+const DEFAULT_BASE_URL = 'http://192.168.10.149:8000/v3';
+const URI_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+};
+const INPUT_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+  headers: {},
+};
 
 /**
  * This is a sample server Petstore server. For this sample, you can use the api key \`special-key\` to test the authorization filters. For OAuth2 flow, you may use \`user\` as both username and password when asked to login.
@@ -1121,13 +1593,157 @@ const API = {
   deleteUser,
 };
 
+export const APIURIBuilders = {
+  updatePet: buildUpdatePetURI,
+  addPet: buildAddPetURI,
+  findPetsByStatus: buildFindPetsByStatusURI,
+  findPetsByTags: buildFindPetsByTagsURI,
+  getPetById: buildGetPetByIdURI,
+  updatePetWithForm: buildUpdatePetWithFormURI,
+  deletePet: buildDeletePetURI,
+  uploadFile: buildUploadFileURI,
+  getInventory: buildGetInventoryURI,
+  placeOrder: buildPlaceOrderURI,
+  getOrderById: buildGetOrderByIdURI,
+  deleteOrder: buildDeleteOrderURI,
+  createUser: buildCreateUserURI,
+  createUsersWithArrayInput: buildCreateUsersWithArrayInputURI,
+  createUsersWithListInput: buildCreateUsersWithListInputURI,
+  loginUser: buildLoginUserURI,
+  logoutUser: buildLogoutUserURI,
+  getUserByName: buildGetUserByNameURI,
+  updateUser: buildUpdateUserURI,
+  deleteUser: buildDeleteUserURI,
+};
+
+export const APIMethods = {
+  updatePet: 'put',
+  addPet: 'post',
+  findPetsByStatus: 'get',
+  findPetsByTags: 'get',
+  getPetById: 'get',
+  updatePetWithForm: 'post',
+  deletePet: 'delete',
+  uploadFile: 'post',
+  getInventory: 'get',
+  placeOrder: 'post',
+  getOrderById: 'get',
+  deleteOrder: 'delete',
+  createUser: 'post',
+  createUsersWithArrayInput: 'post',
+  createUsersWithListInput: 'post',
+  loginUser: 'get',
+  logoutUser: 'get',
+  getUserByName: 'get',
+  updateUser: 'put',
+  deleteUser: 'delete',
+} as const;
+
+export const APIInputBuilders = {
+  updatePet: buildUpdatePetInput,
+  addPet: buildAddPetInput,
+  findPetsByStatus: buildFindPetsByStatusInput,
+  findPetsByTags: buildFindPetsByTagsInput,
+  getPetById: buildGetPetByIdInput,
+  updatePetWithForm: buildUpdatePetWithFormInput,
+  deletePet: buildDeletePetInput,
+  uploadFile: buildUploadFileInput,
+  getInventory: buildGetInventoryInput,
+  placeOrder: buildPlaceOrderInput,
+  getOrderById: buildGetOrderByIdInput,
+  deleteOrder: buildDeleteOrderInput,
+  createUser: buildCreateUserInput,
+  createUsersWithArrayInput: buildCreateUsersWithArrayInputInput,
+  createUsersWithListInput: buildCreateUsersWithListInputInput,
+  loginUser: buildLoginUserInput,
+  logoutUser: buildLogoutUserInput,
+  getUserByName: buildGetUserByNameInput,
+  updateUser: buildUpdateUserInput,
+  deleteUser: buildDeleteUserInput,
+};
+
+
+/**
+ * Build the \\"updatePet\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildUpdatePetURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'pet',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"updatePet\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildUpdatePetInput(
+  {
+    body,
+  } : APITypes.UpdatePet.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.UpdatePet.Input['body']> {
+
+
+
+  const __method = APIMethods.updatePet;
+  const __uriData = buildUpdatePetURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
 
 /**
  * Update an existing pet
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1137,32 +1753,24 @@ async function updatePet(
   {
     body,
   } : APITypes.UpdatePet.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.UpdatePet.Output>> {
-
-
-
-  const method = 'put';
-  const urlParts = [
-    'pet',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildUpdatePetInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1172,12 +1780,88 @@ async function updatePet(
   } as APITypes.UpdatePet.Output;
 }
 
+
+/**
+ * Build the \\"addPet\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildAddPetURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'pet',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"addPet\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildAddPetInput(
+  {
+    body,
+  } : APITypes.AddPet.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.AddPet.Input['body']> {
+
+
+
+  const __method = APIMethods.addPet;
+  const __uriData = buildAddPetURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Add a new pet to the store
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1187,32 +1871,24 @@ async function addPet(
   {
     body,
   } : APITypes.AddPet.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.AddPet.Output>> {
-
-
-
-  const method = 'post';
-  const urlParts = [
-    'pet',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildAddPetInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1222,11 +1898,99 @@ async function addPet(
   } as APITypes.AddPet.Output;
 }
 
+
+/**
+ * Build the \\"findPetsByStatus\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {array} parameters.status
+ * Status values that need to be considered for filter
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildFindPetsByStatusURI(
+  {
+    status,
+  } : Pick<APITypes.FindPetsByStatus.Input,
+    'status'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(status == null) {
+    throw new Error('Missing required parameter : status. Value : ' +  status);
+  }
+
+  const __pathParts = [
+    'pet',
+    'findByStatus',
+  ];
+  const __qs = cleanQuery({
+    status: status,
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"findPetsByStatus\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {array} parameters.status
+ * Status values that need to be considered for filter
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildFindPetsByStatusInput(
+  {
+    status,
+  } : APITypes.FindPetsByStatus.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.findPetsByStatus;
+  const __uriData = buildFindPetsByStatusURI({
+    status,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Finds Pets by status
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {array} parameters.status
+ * The parameters provided to build them (destructured)
+* @param {array} parameters.status
  * Status values that need to be considered for filter
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1235,40 +1999,26 @@ async function addPet(
  */
 async function findPetsByStatus(
   {
-  status,
+    status,
   } : APITypes.FindPetsByStatus.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.FindPetsByStatus.Output>> {
-
-
-  if( status == null) {
-    throw new Error('Missing required parameter : status. Value : ' +  status);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'pet',
-    'findByStatus',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-    status: status,
-  });
-  const data = undefined;
+  const httpRequest = buildFindPetsByStatusInput({
+    status,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1278,11 +2028,99 @@ async function findPetsByStatus(
   } as APITypes.FindPetsByStatus.Output;
 }
 
+
+/**
+ * Build the \\"findPetsByTags\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {array} parameters.tags
+ * Tags to filter by
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildFindPetsByTagsURI(
+  {
+    tags,
+  } : Pick<APITypes.FindPetsByTags.Input,
+    'tags'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(tags == null) {
+    throw new Error('Missing required parameter : tags. Value : ' +  tags);
+  }
+
+  const __pathParts = [
+    'pet',
+    'findByTags',
+  ];
+  const __qs = cleanQuery({
+    tags: tags,
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"findPetsByTags\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {array} parameters.tags
+ * Tags to filter by
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildFindPetsByTagsInput(
+  {
+    tags,
+  } : APITypes.FindPetsByTags.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.findPetsByTags;
+  const __uriData = buildFindPetsByTagsURI({
+    tags,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Finds Pets by tags
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {array} parameters.tags
+ * The parameters provided to build them (destructured)
+* @param {array} parameters.tags
  * Tags to filter by
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1291,40 +2129,26 @@ async function findPetsByStatus(
  */
 async function findPetsByTags(
   {
-  tags,
+    tags,
   } : APITypes.FindPetsByTags.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.FindPetsByTags.Output>> {
-
-
-  if( tags == null) {
-    throw new Error('Missing required parameter : tags. Value : ' +  tags);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'pet',
-    'findByTags',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-    tags: tags,
-  });
-  const data = undefined;
+  const httpRequest = buildFindPetsByTagsInput({
+    tags,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1334,11 +2158,98 @@ async function findPetsByTags(
   } as APITypes.FindPetsByTags.Output;
 }
 
+
+/**
+ * Build the \\"getPetById\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {integer} parameters.petId
+ * ID of pet to return
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetPetByIdURI(
+  {
+    petId,
+  } : Pick<APITypes.GetPetById.Input,
+    'petId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(petId == null) {
+    throw new Error('Missing required parameter : petId. Value : ' +  petId);
+  }
+
+  const __pathParts = [
+    'pet',
+    petId,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getPetById\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
+ * ID of pet to return
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetPetByIdInput(
+  {
+    petId,
+  } : APITypes.GetPetById.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getPetById;
+  const __uriData = buildGetPetByIdURI({
+    petId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Find pet by ID
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {integer} parameters.petId
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
  * ID of pet to return
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1347,39 +2258,26 @@ async function findPetsByTags(
  */
 async function getPetById(
   {
-  petId,
-  } : APITypes.GetPetById.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.GetPetById.Output>> {
-
-
-  if( petId == null) {
-    throw new Error('Missing required parameter : petId. Value : ' +  petId);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'pet',
     petId,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.GetPetById.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.GetPetById.Output>> {
+  const httpRequest = buildGetPetByIdInput({
+    petId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1389,13 +2287,103 @@ async function getPetById(
   } as APITypes.GetPetById.Output;
 }
 
+
+/**
+ * Build the \\"updatePetWithForm\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {integer} parameters.petId
+ * ID of pet that needs to be updated
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildUpdatePetWithFormURI(
+  {
+    petId,
+  } : Pick<APITypes.UpdatePetWithForm.Input,
+    'petId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(petId == null) {
+    throw new Error('Missing required parameter : petId. Value : ' +  petId);
+  }
+
+  const __pathParts = [
+    'pet',
+    petId,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"updatePetWithForm\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
+ * ID of pet that needs to be updated
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildUpdatePetWithFormInput(
+  {
+    body,
+    petId,
+  } : APITypes.UpdatePetWithForm.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.UpdatePetWithForm.Input['body']> {
+
+
+
+  const __method = APIMethods.updatePetWithForm;
+  const __uriData = buildUpdatePetWithFormURI({
+    petId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Updates a pet in the store with form data
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
- * @param {integer} parameters.petId
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
  * ID of pet that needs to be updated
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1405,39 +2393,27 @@ async function getPetById(
 async function updatePetWithForm(
   {
     body,
-  petId,
-  } : APITypes.UpdatePetWithForm.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.UpdatePetWithForm.Output>> {
-
-
-  if( petId == null) {
-    throw new Error('Missing required parameter : petId. Value : ' +  petId);
-  }
-
-
-  const method = 'post';
-  const urlParts = [
-    'pet',
     petId,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  } : APITypes.UpdatePetWithForm.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.UpdatePetWithForm.Output>> {
+  const httpRequest = buildUpdatePetWithFormInput({
+    body,
+    petId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1447,12 +2423,102 @@ async function updatePetWithForm(
   } as APITypes.UpdatePetWithForm.Output;
 }
 
+
+/**
+ * Build the \\"deletePet\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {integer} parameters.petId
+ * Pet id to delete
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildDeletePetURI(
+  {
+    petId,
+  } : Pick<APITypes.DeletePet.Input,
+    'petId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(petId == null) {
+    throw new Error('Missing required parameter : petId. Value : ' +  petId);
+  }
+
+  const __pathParts = [
+    'pet',
+    petId,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"deletePet\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} [parameters.apiKey],
+* @param {integer} parameters.petId
+ * Pet id to delete
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildDeletePetInput(
+  {
+    apiKey,
+    petId,
+  } : APITypes.DeletePet.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.deletePet;
+  const __uriData = buildDeletePetURI({
+    petId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+      'api_key': apiKey,
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Deletes a pet
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {string} [parameters.apiKey],
- * @param {integer} parameters.petId
+ * The parameters provided to build them (destructured)
+* @param {string} [parameters.apiKey],
+* @param {integer} parameters.petId
  * Pet id to delete
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1461,41 +2527,28 @@ async function updatePetWithForm(
  */
 async function deletePet(
   {
-  apiKey,
-  petId,
-  } : APITypes.DeletePet.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.DeletePet.Output>> {
-
-
-  if( petId == null) {
-    throw new Error('Missing required parameter : petId. Value : ' +  petId);
-  }
-
-
-  const method = 'delete';
-  const urlParts = [
-    'pet',
+    apiKey,
     petId,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-    'api_key': apiKey,
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.DeletePet.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.DeletePet.Output>> {
+  const httpRequest = buildDeletePetInput({
+    apiKey,
+    petId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1505,13 +2558,104 @@ async function deletePet(
   } as APITypes.DeletePet.Output;
 }
 
+
+/**
+ * Build the \\"uploadFile\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {integer} parameters.petId
+ * ID of pet to update
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildUploadFileURI(
+  {
+    petId,
+  } : Pick<APITypes.UploadFile.Input,
+    'petId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(petId == null) {
+    throw new Error('Missing required parameter : petId. Value : ' +  petId);
+  }
+
+  const __pathParts = [
+    'pet',
+    petId,
+    'uploadImage',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"uploadFile\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
+ * ID of pet to update
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildUploadFileInput(
+  {
+    body,
+    petId,
+  } : APITypes.UploadFile.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.UploadFile.Input['body']> {
+
+
+
+  const __method = APIMethods.uploadFile;
+  const __uriData = buildUploadFileURI({
+    petId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * uploads an image
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
- * @param {integer} parameters.petId
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.petId
  * ID of pet to update
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1521,40 +2665,27 @@ async function deletePet(
 async function uploadFile(
   {
     body,
-  petId,
-  } : APITypes.UploadFile.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.UploadFile.Output>> {
-
-
-  if( petId == null) {
-    throw new Error('Missing required parameter : petId. Value : ' +  petId);
-  }
-
-
-  const method = 'post';
-  const urlParts = [
-    'pet',
     petId,
-    'uploadImage',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  } : APITypes.UploadFile.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.UploadFile.Output>> {
+  const httpRequest = buildUploadFileInput({
+    body,
+    petId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1564,10 +2695,83 @@ async function uploadFile(
   } as APITypes.UploadFile.Output;
 }
 
+
+/**
+ * Build the \\"getInventory\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetInventoryURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'store',
+    'inventory',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getInventory\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetInventoryInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getInventory;
+  const __uriData = buildGetInventoryURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Returns pet inventories by status
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1575,33 +2779,23 @@ async function uploadFile(
  */
 async function getInventory(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetInventory.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'store',
-    'inventory',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetInventoryInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1611,12 +2805,89 @@ async function getInventory(
   } as APITypes.GetInventory.Output;
 }
 
+
+/**
+ * Build the \\"placeOrder\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildPlaceOrderURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'store',
+    'order',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"placeOrder\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildPlaceOrderInput(
+  {
+    body,
+  } : APITypes.PlaceOrder.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.PlaceOrder.Input['body']> {
+
+
+
+  const __method = APIMethods.placeOrder;
+  const __uriData = buildPlaceOrderURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Place an order for a pet
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1626,33 +2897,24 @@ async function placeOrder(
   {
     body,
   } : APITypes.PlaceOrder.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.PlaceOrder.Output>> {
-
-
-
-  const method = 'post';
-  const urlParts = [
-    'store',
-    'order',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildPlaceOrderInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1662,11 +2924,99 @@ async function placeOrder(
   } as APITypes.PlaceOrder.Output;
 }
 
+
+/**
+ * Build the \\"getOrderById\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {integer} parameters.orderId
+ * ID of pet that needs to be fetched
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetOrderByIdURI(
+  {
+    orderId,
+  } : Pick<APITypes.GetOrderById.Input,
+    'orderId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(orderId == null) {
+    throw new Error('Missing required parameter : orderId. Value : ' +  orderId);
+  }
+
+  const __pathParts = [
+    'store',
+    'order',
+    orderId,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getOrderById\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.orderId
+ * ID of pet that needs to be fetched
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetOrderByIdInput(
+  {
+    orderId,
+  } : APITypes.GetOrderById.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getOrderById;
+  const __uriData = buildGetOrderByIdURI({
+    orderId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Find purchase order by ID
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {integer} parameters.orderId
+ * The parameters provided to build them (destructured)
+* @param {integer} parameters.orderId
  * ID of pet that needs to be fetched
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1675,40 +3025,26 @@ async function placeOrder(
  */
 async function getOrderById(
   {
-  orderId,
-  } : APITypes.GetOrderById.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.GetOrderById.Output>> {
-
-
-  if( orderId == null) {
-    throw new Error('Missing required parameter : orderId. Value : ' +  orderId);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'store',
-    'order',
     orderId,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.GetOrderById.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.GetOrderById.Output>> {
+  const httpRequest = buildGetOrderByIdInput({
+    orderId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1718,11 +3054,99 @@ async function getOrderById(
   } as APITypes.GetOrderById.Output;
 }
 
+
+/**
+ * Build the \\"deleteOrder\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {string} parameters.orderId
+ * ID of the order that needs to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildDeleteOrderURI(
+  {
+    orderId,
+  } : Pick<APITypes.DeleteOrder.Input,
+    'orderId'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(orderId == null) {
+    throw new Error('Missing required parameter : orderId. Value : ' +  orderId);
+  }
+
+  const __pathParts = [
+    'store',
+    'order',
+    orderId,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"deleteOrder\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.orderId
+ * ID of the order that needs to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildDeleteOrderInput(
+  {
+    orderId,
+  } : APITypes.DeleteOrder.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.deleteOrder;
+  const __uriData = buildDeleteOrderURI({
+    orderId,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Delete purchase order by ID
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {string} parameters.orderId
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.orderId
  * ID of the order that needs to be deleted
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1731,40 +3155,26 @@ async function getOrderById(
  */
 async function deleteOrder(
   {
-  orderId,
-  } : APITypes.DeleteOrder.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.DeleteOrder.Output>> {
-
-
-  if( orderId == null) {
-    throw new Error('Missing required parameter : orderId. Value : ' +  orderId);
-  }
-
-
-  const method = 'delete';
-  const urlParts = [
-    'store',
-    'order',
     orderId,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.DeleteOrder.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.DeleteOrder.Output>> {
+  const httpRequest = buildDeleteOrderInput({
+    orderId,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1774,12 +3184,88 @@ async function deleteOrder(
   } as APITypes.DeleteOrder.Output;
 }
 
+
+/**
+ * Build the \\"createUser\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildCreateUserURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'user',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"createUser\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildCreateUserInput(
+  {
+    body,
+  } : APITypes.CreateUser.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.CreateUser.Input['body']> {
+
+
+
+  const __method = APIMethods.createUser;
+  const __uriData = buildCreateUserURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Create user
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1789,32 +3275,24 @@ async function createUser(
   {
     body,
   } : APITypes.CreateUser.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.CreateUser.Output>> {
-
-
-
-  const method = 'post';
-  const urlParts = [
-    'user',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildCreateUserInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1824,12 +3302,89 @@ async function createUser(
   } as APITypes.CreateUser.Output;
 }
 
+
+/**
+ * Build the \\"createUsersWithArrayInput\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildCreateUsersWithArrayInputURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'user',
+    'createWithArray',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"createUsersWithArrayInput\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildCreateUsersWithArrayInputInput(
+  {
+    body,
+  } : APITypes.CreateUsersWithArrayInput.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.CreateUsersWithArrayInput.Input['body']> {
+
+
+
+  const __method = APIMethods.createUsersWithArrayInput;
+  const __uriData = buildCreateUsersWithArrayInputURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Creates list of users with given input array
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1839,33 +3394,24 @@ async function createUsersWithArrayInput(
   {
     body,
   } : APITypes.CreateUsersWithArrayInput.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.CreateUsersWithArrayInput.Output>> {
-
-
-
-  const method = 'post';
-  const urlParts = [
-    'user',
-    'createWithArray',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildCreateUsersWithArrayInputInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1875,12 +3421,89 @@ async function createUsersWithArrayInput(
   } as APITypes.CreateUsersWithArrayInput.Output;
 }
 
+
+/**
+ * Build the \\"createUsersWithListInput\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildCreateUsersWithListInputURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'user',
+    'createWithList',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"createUsersWithListInput\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildCreateUsersWithListInputInput(
+  {
+    body,
+  } : APITypes.CreateUsersWithListInput.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.CreateUsersWithListInput.Input['body']> {
+
+
+
+  const __method = APIMethods.createUsersWithListInput;
+  const __uriData = buildCreateUsersWithListInputURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Creates list of users with given input array
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -1890,33 +3513,24 @@ async function createUsersWithListInput(
   {
     body,
   } : APITypes.CreateUsersWithListInput.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.CreateUsersWithListInput.Output>> {
-
-
-
-  const method = 'post';
-  const urlParts = [
-    'user',
-    'createWithList',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildCreateUsersWithListInputInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1926,13 +3540,113 @@ async function createUsersWithListInput(
   } as APITypes.CreateUsersWithListInput.Output;
 }
 
+
+/**
+ * Build the \\"loginUser\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {string} parameters.username
+ * The user name for login,
+* @param {string} parameters.password
+ * The password for login in clear text
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildLoginUserURI(
+  {
+    username,
+    password,
+  } : Pick<APITypes.LoginUser.Input,
+    'username'|
+    'password'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(username == null) {
+    throw new Error('Missing required parameter : username. Value : ' +  username);
+  }
+  if(password == null) {
+    throw new Error('Missing required parameter : password. Value : ' +  password);
+  }
+
+  const __pathParts = [
+    'user',
+    'login',
+  ];
+  const __qs = cleanQuery({
+    username: username,
+    password: password,
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"loginUser\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
+ * The user name for login,
+* @param {string} parameters.password
+ * The password for login in clear text
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildLoginUserInput(
+  {
+    username,
+    password,
+  } : APITypes.LoginUser.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.loginUser;
+  const __uriData = buildLoginUserURI({
+    username,
+    password,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Logs user into the system
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {string} parameters.username
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
  * The user name for login,
- * @param {string} parameters.password
+* @param {string} parameters.password
  * The password for login in clear text
  * @param {Object} options
  * Options to override Axios request configuration
@@ -1941,46 +3655,28 @@ async function createUsersWithListInput(
  */
 async function loginUser(
   {
-  username,
-  password,
+    username,
+    password,
   } : APITypes.LoginUser.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.LoginUser.Output>> {
-
-
-  if( username == null) {
-    throw new Error('Missing required parameter : username. Value : ' +  username);
-  }
-
-  if( password == null) {
-    throw new Error('Missing required parameter : password. Value : ' +  password);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'user',
-    'login',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-    username: username,
-    password: password,
-  });
-  const data = undefined;
+  const httpRequest = buildLoginUserInput({
+    username,
+    password,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -1990,10 +3686,83 @@ async function loginUser(
   } as APITypes.LoginUser.Output;
 }
 
+
+/**
+ * Build the \\"logoutUser\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildLogoutUserURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'user',
+    'logout',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"logoutUser\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildLogoutUserInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.logoutUser;
+  const __uriData = buildLogoutUserURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Logs out current logged in user session
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -2001,33 +3770,23 @@ async function loginUser(
  */
 async function logoutUser(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.LogoutUser.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'user',
-    'logout',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildLogoutUserInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -2037,11 +3796,98 @@ async function logoutUser(
   } as APITypes.LogoutUser.Output;
 }
 
+
+/**
+ * Build the \\"getUserByName\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {string} parameters.username
+ * The name that needs to be fetched. Use user1 for testing.
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetUserByNameURI(
+  {
+    username,
+  } : Pick<APITypes.GetUserByName.Input,
+    'username'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(username == null) {
+    throw new Error('Missing required parameter : username. Value : ' +  username);
+  }
+
+  const __pathParts = [
+    'user',
+    username,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getUserByName\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
+ * The name that needs to be fetched. Use user1 for testing.
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetUserByNameInput(
+  {
+    username,
+  } : APITypes.GetUserByName.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getUserByName;
+  const __uriData = buildGetUserByNameURI({
+    username,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Get user by user name
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {string} parameters.username
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
  * The name that needs to be fetched. Use user1 for testing.
  * @param {Object} options
  * Options to override Axios request configuration
@@ -2050,39 +3896,26 @@ async function logoutUser(
  */
 async function getUserByName(
   {
-  username,
-  } : APITypes.GetUserByName.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.GetUserByName.Output>> {
-
-
-  if( username == null) {
-    throw new Error('Missing required parameter : username. Value : ' +  username);
-  }
-
-
-  const method = 'get';
-  const urlParts = [
-    'user',
     username,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.GetUserByName.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.GetUserByName.Output>> {
+  const httpRequest = buildGetUserByNameInput({
+    username,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -2092,13 +3925,103 @@ async function getUserByName(
   } as APITypes.GetUserByName.Output;
 }
 
+
+/**
+ * Build the \\"updateUser\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {string} parameters.username
+ * name that need to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildUpdateUserURI(
+  {
+    username,
+  } : Pick<APITypes.UpdateUser.Input,
+    'username'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(username == null) {
+    throw new Error('Missing required parameter : username. Value : ' +  username);
+  }
+
+  const __pathParts = [
+    'user',
+    username,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"updateUser\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
+ * name that need to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildUpdateUserInput(
+  {
+    body,
+    username,
+  } : APITypes.UpdateUser.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.UpdateUser.Input['body']> {
+
+
+
+  const __method = APIMethods.updateUser;
+  const __uriData = buildUpdateUserURI({
+    username,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
+
 /**
  * Updated user
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
- * @param {string} parameters.username
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
  * name that need to be deleted
  * @param {Object} options
  * Options to override Axios request configuration
@@ -2108,39 +4031,27 @@ async function getUserByName(
 async function updateUser(
   {
     body,
-  username,
-  } : APITypes.UpdateUser.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.UpdateUser.Output>> {
-
-
-  if( username == null) {
-    throw new Error('Missing required parameter : username. Value : ' +  username);
-  }
-
-
-  const method = 'put';
-  const urlParts = [
-    'user',
     username,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  } : APITypes.UpdateUser.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.UpdateUser.Output>> {
+  const httpRequest = buildUpdateUserInput({
+    body,
+    username,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -2150,11 +4061,98 @@ async function updateUser(
   } as APITypes.UpdateUser.Output;
 }
 
+
+/**
+ * Build the \\"deleteUser\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+* @param {string} parameters.username
+ * The name that needs to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildDeleteUserURI(
+  {
+    username,
+  } : Pick<APITypes.DeleteUser.Input,
+    'username'
+      >,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+  if(username == null) {
+    throw new Error('Missing required parameter : username. Value : ' +  username);
+  }
+
+  const __pathParts = [
+    'user',
+    username,
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"deleteUser\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
+ * The name that needs to be deleted
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildDeleteUserInput(
+  {
+    username,
+  } : APITypes.DeleteUser.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.deleteUser;
+  const __uriData = buildDeleteUserURI({
+    username,
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '1.0.0',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
+
 /**
  * Delete user
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
- * @param {string} parameters.username
+ * The parameters provided to build them (destructured)
+* @param {string} parameters.username
  * The name that needs to be deleted
  * @param {Object} options
  * Options to override Axios request configuration
@@ -2163,39 +4161,26 @@ async function updateUser(
  */
 async function deleteUser(
   {
-  username,
-  } : APITypes.DeleteUser.Input,
-  options: AxiosRequestConfig = {}
-) : Promise<Writeable<APITypes.DeleteUser.Output>> {
-
-
-  if( username == null) {
-    throw new Error('Missing required parameter : username. Value : ' +  username);
-  }
-
-
-  const method = 'delete';
-  const urlParts = [
-    'user',
     username,
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '1.0.0',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  } : APITypes.DeleteUser.Input,
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
+) : Promise<Writeable<APITypes.DeleteUser.Output>> {
+  const httpRequest = buildDeleteUserInput({
+    username,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -2239,14 +4224,34 @@ exports[`generateSDKFromOpenAPI should work with filterStatuses 1`] = `
 // do not change it in place it would be overridden
 // by the next build
 
+import querystring from 'querystring';
+import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+
 type Writeable<T extends { [x: string]: unknown }> = {
   [P in keyof T]: T[P];
 };
-type QueryParams = {
+export type Method = 'options' | 'get' | 'head' |'post' | 'put' | 'patch' | 'delete';
+export type QueryParams = {
   [name: string]: string | number | string[] | number[] | boolean | undefined;
 };
-type Headers = Record<string, string>;
-
+export type Headers = Record<string, string>;
+export type URIBuilderOptions = {
+  baseURL?: string;
+};
+export type InputBuilderOptions = URIBuilderOptions & {
+    headers?: Headers;
+};
+export type URIData = {
+  baseURL: string;
+  path: string;
+  params: QueryParams;
+};
+export type HTTPRequest<T> = URIData & {
+  method: Method;
+  headers: Headers;
+  body: T;
+};
 export type { APITypes, Components };
 
 declare namespace APITypes {
@@ -2277,9 +4282,14 @@ declare namespace Components {
     }
 }
 
-import type { AxiosRequestConfig } from 'axios';
-import querystring from 'querystring';
-import axios from 'axios';
+const DEFAULT_BASE_URL = 'http://192.168.10.149:8000/v3';
+const URI_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+};
+const INPUT_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+  headers: {},
+};
 
 /**
  * A basic Whook server
@@ -2290,11 +4300,94 @@ const API = {
   getPing,
 };
 
+export const APIURIBuilders = {
+  getPing: buildGetPingURI,
+};
+
+export const APIMethods = {
+  getPing: 'get',
+} as const;
+
+export const APIInputBuilders = {
+  getPing: buildGetPingInput,
+};
+
+
+/**
+ * Build the \\"getPing\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildGetPingURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'ping',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"getPing\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildGetPingInput(
+  _: unknown,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<undefined> {
+
+
+
+  const __method = APIMethods.getPing;
+  const __uriData = buildGetPingURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: undefined,
+  };
+}
 
 /**
  * Checks API's availability.
+ * @return {Object}
+ * The object describing the built parameters
  * @param {Object} parameters
- * The parameters to provide (destructured)
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -2302,32 +4395,23 @@ const API = {
  */
 async function getPing(
   _: unknown,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.GetPing.Output>> {
-
-
-
-  const method = 'get';
-  const urlParts = [
-    'ping',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = undefined;
+  const httpRequest = buildGetPingInput({
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {
@@ -2371,14 +4455,34 @@ exports[`generateSDKFromOpenAPI should work with refs 1`] = `
 // do not change it in place it would be overridden
 // by the next build
 
+import querystring from 'querystring';
+import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+
 type Writeable<T extends { [x: string]: unknown }> = {
   [P in keyof T]: T[P];
 };
-type QueryParams = {
+export type Method = 'options' | 'get' | 'head' |'post' | 'put' | 'patch' | 'delete';
+export type QueryParams = {
   [name: string]: string | number | string[] | number[] | boolean | undefined;
 };
-type Headers = Record<string, string>;
-
+export type Headers = Record<string, string>;
+export type URIBuilderOptions = {
+  baseURL?: string;
+};
+export type InputBuilderOptions = URIBuilderOptions & {
+    headers?: Headers;
+};
+export type URIData = {
+  baseURL: string;
+  path: string;
+  params: QueryParams;
+};
+export type HTTPRequest<T> = URIData & {
+  method: Method;
+  headers: Headers;
+  body: T;
+};
 export type { APITypes, Components };
 
 declare namespace APITypes {
@@ -2418,9 +4522,14 @@ declare namespace Components {
     }
 }
 
-import type { AxiosRequestConfig } from 'axios';
-import querystring from 'querystring';
-import axios from 'axios';
+const DEFAULT_BASE_URL = 'http://192.168.10.149:8000/v3';
+const URI_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+};
+const INPUT_BUILDER_DEFAULTS = {
+  baseURL: DEFAULT_BASE_URL,
+  headers: {},
+};
 
 /**
  * A basic Whook server
@@ -2431,13 +4540,100 @@ const API = {
   putEcho,
 };
 
+export const APIURIBuilders = {
+  putEcho: buildPutEchoURI,
+};
+
+export const APIMethods = {
+  putEcho: 'put',
+} as const;
+
+export const APIInputBuilders = {
+  putEcho: buildPutEchoInput,
+};
+
+
+/**
+ * Build the \\"putEcho\\" URI parameters$
+ * @return {Object}
+ * The object describing the built URI
+ * @param {Object} parameters
+ * The parameters provided to build the URI (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ */
+function buildPutEchoURI(
+  _: unknown,
+  {
+    baseURL: __baseURL = DEFAULT_BASE_URL,
+  }: URIBuilderOptions = URI_BUILDER_DEFAULTS,
+) : URIData {
+
+  const __pathParts = [
+    'echo',
+  ];
+  const __qs = cleanQuery({
+  });
+
+  return {
+    baseURL: __baseURL,
+    path: __pathParts.join('/'),
+    params: __qs,
+  };
+}
+
+/**
+ * Build all the \\"putEcho\\" parameters
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
+ * @param {Object} parameters
+ * The parameters provided to build them (destructured)
+ * @param {Object} options
+ * The options (destructured)
+ * @param {string} options.baseURL
+ * The base URL of the API
+ * @param {string} options.headers
+ * Any additional headers to append
+ */
+function buildPutEchoInput(
+  {
+    body,
+  } : APITypes.PutEcho.Input,
+    {
+      baseURL: __baseURL = DEFAULT_BASE_URL,
+      headers: __headers = {},
+    }: InputBuilderOptions = INPUT_BUILDER_DEFAULTS,
+) : HTTPRequest<APITypes.PutEcho.Input['body']> {
+
+
+
+  const __method = APIMethods.putEcho;
+  const __uriData = buildPutEchoURI({
+  }, { baseURL: __baseURL });
+
+  return {
+    method: __method,
+    ...__uriData,
+    headers: cleanHeaders(Object.assign(__headers, {
+      'X-API-Version': '3.1.3',
+      'X-SDK-Version': '1.0.0',
+    })),
+    body: body,
+  };
+}
 
 /**
  * Echoes what it takes.
+ * @return {Object}
+ * The object describing the built parameters
+ * @param {Object} body
+ * The request body
  * @param {Object} parameters
- * The parameters to provide (destructured)
-  @param body The request body
-
+ * The parameters provided to build them (destructured)
  * @param {Object} options
  * Options to override Axios request configuration
  * @return {Object}
@@ -2447,32 +4643,24 @@ async function putEcho(
   {
     body,
   } : APITypes.PutEcho.Input,
-  options: AxiosRequestConfig = {}
+  options: InputBuilderOptions & Partial<AxiosRequestConfig> = {}
 ) : Promise<Writeable<APITypes.PutEcho.Output>> {
-
-
-
-  const method = 'put';
-  const urlParts = [
-    'echo',
-  ];
-  const headers = Object.assign(((options || {}).headers || {}), {
-    'X-API-Version': '3.1.3',
-    'X-SDK-Version': '1.0.0',
-  });
-  const qs = cleanQuery({
-  });
-  const data = body;
+  const httpRequest = buildPutEchoInput({
+    body,
+  }, options);
+  const callOptions = {
+    baseURL: httpRequest.baseURL,
+    method: httpRequest.method,
+    url: httpRequest.path,
+    headers: httpRequest.headers,
+    params: httpRequest.params,
+    data: httpRequest.body,
+  };
 
   const response = await axios(Object.assign({
-    baseURL: 'http://192.168.10.149:8000/v3',
+    ...callOptions,
     paramsSerializer: querystring.stringify.bind(querystring),
     validateStatus: (status: number) => 200 <= status && 300 > status,
-    method: method,
-    url: urlParts.join('/'),
-    headers: cleanHeaders(headers),
-    params: qs,
-    data,
   }, options || {}));
 
   return {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1335,6 +1335,7 @@ describe('generateSDKFromOpenAPI', () => {
         },
       },
     };
+
     expect(
       await generateSDKFromOpenAPI(JSON.stringify(schema), {
         sdkVersion: '1.0.0',


### PR DESCRIPTION
Sometimes, we only need to generate the HTTP parameters not execute the request (for example, to pass the built parameters to a subprocess that will do it, to looks for those uris into some logs...). This allows to create the HTTP URI / Request options and take benefit of the results to either run it or do something else with it.

In fact, we could juste remove `axios` of the generated result so that one can use any of its preferred lib. @Oupsla LMKWYT ;)